### PR TITLE
Fixes #21: Add colors to action buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
       {
         "command": "workspaceTasks.runTask",
         "title": "%command.runTask%",
-        "icon": "$(play)"
+        "icon": "$(debug-start)"
       },
       {
         "command": "workspaceTasks.runTaskWithArgs",
@@ -242,7 +242,7 @@
       {
         "command": "workspaceTasks.stopTask",
         "title": "%command.stopTask%",
-        "icon": "$(stop)"
+        "icon": "$(debug-stop)"
       },
       {
         "command": "workspaceTasks.restartTask",


### PR DESCRIPTION
Was able to find a built in alternative for start/stop buttons. It will now use the debug-start and debug-stop which are green and red. 


New icons:
<img width="345" height="30" alt="image" src="https://github.com/user-attachments/assets/6f51d047-3825-4757-8137-5fc3a6d0e127" />
<img width="332" height="33" alt="image" src="https://github.com/user-attachments/assets/45f63087-1f51-4307-a8b4-165a2530c834" />
