### PR TITLE
v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,47 @@
-## [1.1.5] - 2026-02-02
+## [1.1.6] - 2026-02-03
+
+### 🚀 Features
+
+- *(tasks)* Universal task interfaces initial
+
 
 ### 🐛 Bug Fixes
 
-- *(ux)* Incorrect icons for gradle/makefile/shell
+- Treat vscode tasks as they are natively defined by vscode. #50 #49 #56
 
-- Exclude png files from package as not used in package
 
+
+**Full Changelog**: https://github.com/camalot/vscode-workspace-tasks/compare/v1.1.5...v1.1.6
+
+## [1.1.5] - 2026-02-03
 
 ### 💼 Other
 
-- Ensure that res/icon.png is included in package
+- V1.1.5 (#55)
 
+- * fix(ux): incorrect icons for gradle/makefile/shell
 
-### ⚙️ Miscellaneous Tasks
+- * fix: exclude png files from package as not used in package
 
-- *(repo)* Version bump
+- * chore(deps-dev): bump @typescript-eslint/eslint-plugin from 8.53.1 to 8.54.0 #53
 
-- *(changelog)* Update changelog
+- * chore(deps-dev): bump @typescript-eslint/parser from 8.53.1 to 8.54.0 #52
 
-- *(repo)* Exclude gif from package
+- * chore(deps-dev): bump typescript-eslint from 8.53.1 to 8.54.0 #51
+
+- * chore(repo): version bump
+
+- * chore(changelog): update changelog
+
+- * chore(repo): exclude gif from package
+
+- * ensure that res/icon.png is included in package
+
+- * chore(changelog): fix changelog compare link and regenerate
+
+- * chore(repo): update npm package.lock
+
+- * chore(repo): set remote urls for images
 
 
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Workspace Tasks",
   "description": "A Task Explorer for Visual Studio Code",
   "readme": "README.md",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "engines": {
     "vscode": "^1.108.1"
   },

--- a/src/taskDefinition.ts
+++ b/src/taskDefinition.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-interface IBaseTaskConfiguration {
+export interface IBaseTaskConfiguration {
   type: 'shell' | 'process';
   command: string;
   isBackground?: boolean;
@@ -11,7 +11,7 @@ interface IBaseTaskConfiguration {
   tasks?: (ITaskDescription | ICompoundTaskDescription)[];
 }
 
-interface ITaskConfiguration extends IBaseTaskConfiguration {
+export interface ITaskConfiguration extends IBaseTaskConfiguration {
   version: '2.0.0';
   /**
    * Windows specific task configuration
@@ -29,13 +29,13 @@ interface ITaskConfiguration extends IBaseTaskConfiguration {
   linux?: IBaseTaskConfiguration;
 }
 
-interface ICommandOptions {
+export interface ICommandOptions {
   cwd?: string;
   env?: { [key: string]: string };
   shell?: IShellConfiguration;
 }
 
-interface IShellConfiguration {
+export interface IShellConfiguration {
   executable: string;
   args?: string[];
 }
@@ -44,7 +44,7 @@ interface IShellConfiguration {
  * A description of a problem matcher that detects problems
  * in build output.
  */
-interface IProblemMatcher {
+export interface IProblemMatcher {
   /**
    * The name of a base problem matcher to use. If specified the
    * base problem matcher will be used as a template and properties
@@ -121,7 +121,7 @@ interface IProblemMatcher {
 /**
  * A description to track the start and end of a background task.
  */
-interface IBackgroundMatcher {
+export interface IBackgroundMatcher {
   /**
    * If set to true the watcher is in active mode when the task
    * starts. This is equals of issuing a line that matches the
@@ -140,7 +140,7 @@ interface IBackgroundMatcher {
   endsPattern?: string;
 }
 
-interface IProblemPattern {
+export interface IProblemPattern {
   /**
    * The regular expression to find a problem in the console output of an
    * executed task.
@@ -220,7 +220,7 @@ interface IProblemPattern {
   loop?: boolean;
 }
 
-interface IPresentationOptions {
+export interface IPresentationOptions {
   /**
    * Controls whether the task output is reveal in the user interface.
    * Defaults to `always`.
@@ -264,9 +264,15 @@ interface IPresentationOptions {
    * will use split terminals to present instead of a new terminal panel.
    */
   group?: string;
+
+  /**
+   * Controls whether the terminal is closed when the task ends.
+   * Defaults to `false`.
+   */
+  close?: boolean;
 }
 
-interface ICompoundTaskDescription {
+export interface ICompoundTaskDescription {
   label: string;
   dependsOn?: string[];
   dependsOrder?: 'sequence' | 'parallel';
@@ -276,7 +282,7 @@ interface ICompoundTaskDescription {
 /**
  * The description of a task.
  */
-interface ITaskDescription {
+export interface ITaskDescription {
   /**
    * The task's name
    */
@@ -293,6 +299,12 @@ interface ITaskDescription {
    * command line including any additional arguments passed to the command.
    */
   command: string;
+
+  /**
+   * The command options such as the current working directory
+   * and environment variables.
+   */
+  options?: ICommandOptions;
 
   /**
    * Whether the executed command is kept alive and runs in the background.
@@ -334,7 +346,7 @@ interface ITaskDescription {
 /**
  * A description to when and how run a task.
  */
-interface IRunOptions {
+export interface IRunOptions {
   /**
    * Controls how variables are evaluated when a task is executed through
    * the Rerun Last Task command.

--- a/src/taskDefinition.ts
+++ b/src/taskDefinition.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 interface IBaseTaskConfiguration {
-  type: 'shell | process';
+  type: 'shell' | 'process';
   command: string;
   isBackground?: boolean;
   args?: string[];
@@ -309,7 +309,7 @@ interface ITaskDescription {
    * Defines the group to which this task belongs. Also supports to mark
    * a task as the default task in a group.
    */
-  group?: 'build' | 'test' | { kind: 'build' | 'test'; isDefault: boolean };
+  group?: string | { kind: string; isDefault: boolean };
 
   /**
    * The presentation options.

--- a/src/taskFactory.ts
+++ b/src/taskFactory.ts
@@ -691,8 +691,9 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
     case 'vscode': {
       // Use existing Visual Studio Code task defined in .vscode/tasks.json
       const tasks = await vscode.tasks.fetchTasks();
-      const targetWorkspaceFolder = item.taskFileUri || item.resourceUri
-        ? vscode.workspace.getWorkspaceFolder(item.taskFileUri! || item.resourceUri)
+      const taskUri = item.taskFileUri || item.resourceUri;
+      const targetWorkspaceFolder = taskUri
+        ? vscode.workspace.getWorkspaceFolder(taskUri)
         : undefined;
 
       const found = tasks.find((t) => {

--- a/src/taskFactory.ts
+++ b/src/taskFactory.ts
@@ -16,7 +16,6 @@ import { GithubActionsTaskProvider } from './providers/githubActionsTaskProvider
 import { MiseTaskProvider } from './providers/miseTaskProvider';
 import { MavenTaskProvider } from './providers/mavenTaskProvider';
 import { DenoTaskProvider } from './providers/denoTaskProvider';
-import { ITaskDescription } from './taskDefinition';
 
 export interface CreatedTask {
   task: vscode.Task;
@@ -89,7 +88,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         const shellExec = new vscode.ShellExecution(npmCmd, npmArgs, { cwd });
 
         const task = new vscode.Task(
-          { type: 'process', script: 'install', path: resourceUri.fsPath },
+          { type: 'npm', script: 'install', path: resourceUri.fsPath },
           vscode.TaskScope.Workspace,
           taskLabel,
           'npm',
@@ -712,7 +711,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
       });
 
       if (found) {
-        return { task: found, cwd: undefined, native: true};
+        return { task: found, cwd: undefined, native: true };
       }
       return undefined;
     }

--- a/src/taskFactory.ts
+++ b/src/taskFactory.ts
@@ -16,11 +16,13 @@ import { GithubActionsTaskProvider } from './providers/githubActionsTaskProvider
 import { MiseTaskProvider } from './providers/miseTaskProvider';
 import { MavenTaskProvider } from './providers/mavenTaskProvider';
 import { DenoTaskProvider } from './providers/denoTaskProvider';
+import { ITaskDescription } from './taskDefinition';
 
 export interface CreatedTask {
   task: vscode.Task;
   command?: string; // the resolved shell command string (if any)
-  cwd: string;
+  cwd?: string;
+  native: boolean;
 }
 
 export async function createTaskForItem(item: TaskItem, args?: string): Promise<CreatedTask | undefined> {
@@ -58,7 +60,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         new vscode.ShellExecution(fullCommand, { cwd }),
       );
 
-      return { task, command: fullCommand, cwd };
+      return { task, command: fullCommand, cwd, native: false };
     }
   }
 
@@ -87,13 +89,13 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         const shellExec = new vscode.ShellExecution(npmCmd, npmArgs, { cwd });
 
         const task = new vscode.Task(
-          { type: 'npm', script: 'install', path: resourceUri.fsPath },
+          { type: 'process', script: 'install', path: resourceUri.fsPath },
           vscode.TaskScope.Workspace,
           taskLabel,
           'npm',
           shellExec,
         );
-        return { task, command: full, cwd };
+        return { task, command: full, cwd, native: false };
       }
 
       npmArgs.push('run', `${taskLabel}`);
@@ -111,7 +113,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'npm',
         shellExec,
       );
-      return { task, command: full, cwd };
+      return { task, command: full, cwd, native: false };
     }
     case 'yarn': {
       const yarnProvider = new YarnTaskProvider();
@@ -134,7 +136,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'yarn',
         shellExec,
       );
-      return { task, command: full, cwd };
+      return { task, command: full, cwd, native: false };
     }
     case 'pnpm': {
       const pnpmProvider = new PnpmTaskProvider();
@@ -157,7 +159,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'pnpm',
         shellExec,
       );
-      return { task, command: full, cwd };
+      return { task, command: full, cwd, native: false };
     }
     case 'deno': {
       // deno task <taskLabel> [args]
@@ -193,7 +195,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'deno',
         shellExec,
       );
-      return { task, command: full, cwd: denoCwd };
+      return { task, command: full, cwd: denoCwd, native: false };
     }
     case 'mise': {
       // mise run <taskLabel> [args]
@@ -217,7 +219,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'mise',
         shellExec,
       );
-      return { task, command: full, cwd: miseCwd };
+      return { task, command: full, cwd: miseCwd, native: false };
     }
     case 'jupyter': {
       // Use CustomExecution to run Jupyter cell via Visual Studio Code command
@@ -230,7 +232,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
           return new JupyterTerm(resourceUri, item.metadata?.cellIndex, taskLabel);
         }),
       );
-      return { task, command: 'jupyter.runcell', cwd: path.dirname(resourceUri.fsPath) };
+      return { task, command: 'jupyter.runcell', cwd: path.dirname(resourceUri.fsPath), native: false };
     }
     case 'maven': {
       // mvn <goal> [args]
@@ -254,7 +256,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'maven',
         shellExec,
       );
-      return { task, command: full, cwd: mvnCwd };
+      return { task, command: full, cwd: mvnCwd, native: false };
     }
     case 'gradle': {
       // gradle [task] [args]
@@ -282,7 +284,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'gradle',
         shellExec,
       );
-      return { task, command: full, cwd: gradleCwd };
+      return { task, command: full, cwd: gradleCwd, native: false };
     }
     case 'composer': {
       // composer run-script [script] [args]
@@ -311,7 +313,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'composer',
         shellExec,
       );
-      return { task, command: full, cwd: composerCwd };
+      return { task, command: full, cwd: composerCwd, native: false };
     }
     case 'shell': {
       if (!resourceUri) {
@@ -350,7 +352,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'shell',
         shellExec,
       );
-      return { task, command: commandString, cwd };
+      return { task, command: commandString, cwd, native: false };
     }
     case 'grunt': {
       const gruntProvider = new GruntTaskProvider();
@@ -387,7 +389,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'grunt',
         new vscode.ShellExecution(gruntCmd, gruntArgs, { cwd: gruntCwd }),
       );
-      return { task, command: `${gruntCmd} ${gruntArgs.join(' ')}`.trim(), cwd: gruntCwd };
+      return { task, command: `${gruntCmd} ${gruntArgs.join(' ')}`.trim(), cwd: gruntCwd, native: false };
     }
     case 'gulp': {
       // Use npx to prefer workspace-local gulp if available
@@ -435,7 +437,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
       // Debug info to help diagnose incorrect gulpfile selection
       // console.log(`[TaskFactory] Gulp task created. cwd=${gulpCwd}, args=${JSON.stringify(gulpArgs)}`);
 
-      return { task, command: `${gulpCmd} ${gulpArgs.join(' ')}`.trim(), cwd: gulpCwd };
+      return { task, command: `${gulpCmd} ${gulpArgs.join(' ')}`.trim(), cwd: gulpCwd, native: false };
     }
     case 'ant': {
       const antProvider = new AntTaskProvider();
@@ -475,7 +477,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
           'ant',
           new vscode.ShellExecution(fullCommand, { cwd: antCwd }),
         );
-        return { task, command: fullCommand, cwd: antCwd };
+        return { task, command: fullCommand, cwd: antCwd, native: false };
       } else {
         const task = new vscode.Task(
           { type: 'ant', target: taskLabel, path: resourceUri.fsPath },
@@ -484,7 +486,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
           'ant',
           new vscode.ShellExecution(command, commandArgs, { cwd: antCwd }),
         );
-        return { task, command: `${command} ${commandArgs.join(' ')}`, cwd: antCwd };
+        return { task, command: `${command} ${commandArgs.join(' ')}`, cwd: antCwd, native: false };
       }
     }
     case 'workspace-task': {
@@ -500,7 +502,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
           'workspace-task',
           new vscode.ShellExecution(fullCommand, { cwd }),
         );
-        return { task, command: fullCommand, cwd };
+        return { task, command: fullCommand, cwd, native: false };
       }
       return undefined;
     }
@@ -684,13 +686,13 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
       const safeCmd = /\s/.test(actPath) ? `"${actPath}"` : actPath;
       const full = `${safeCmd} ${actArgs.map((a) => (/\s/.test(a) ? `"${a}"` : a)).join(' ')}`;
 
-      return { task, command: full, cwd: actCwd };
+      return { task, command: full, cwd: actCwd, native: false };
     }
     case 'vscode': {
       // Use existing Visual Studio Code task defined in .vscode/tasks.json
       const tasks = await vscode.tasks.fetchTasks();
-      const targetWorkspaceFolder = item.resourceUri
-        ? vscode.workspace.getWorkspaceFolder(item.resourceUri)
+      const targetWorkspaceFolder = item.taskFileUri || item.resourceUri
+        ? vscode.workspace.getWorkspaceFolder(item.taskFileUri! || item.resourceUri)
         : undefined;
 
       const found = tasks.find((t) => {
@@ -709,14 +711,18 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
       });
 
       if (found) {
-        return { task: found, cwd };
+        return { task: found, cwd: undefined, native: true};
       }
       return undefined;
     }
     case 'makefile': {
       const makeProvider = new MakefileTaskProvider();
       const workspaceFolder = vscode.workspace.getWorkspaceFolder(resourceUri);
-      const { command: makeCmd, args: makeInitialArgs, cwd: makeCwd } = makeProvider.getCommand(workspaceFolder?.uri);
+      // cwd needs to be the workspace folder where Makefile is located
+      // use resourceUri to find the makefile location if possible
+      const makeFileCwd = path.dirname(resourceUri.fsPath);
+
+      const { command: makeCmd, args: makeInitialArgs } = makeProvider.getCommand(workspaceFolder?.uri);
 
       const makeArgs = makeInitialArgs ? [...makeInitialArgs] : [];
       makeArgs.push(taskLabel);
@@ -725,16 +731,16 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
       }
 
       const full = `${makeCmd} ${makeArgs.join(' ')}`;
-      const shellExec = new vscode.ShellExecution(makeCmd, makeArgs, { cwd: makeCwd });
+      const shellExec = new vscode.ShellExecution(makeCmd, makeArgs, { cwd: makeFileCwd });
 
       const task = new vscode.Task(
-        { type: 'makefile', script: taskLabel, path: resourceUri.fsPath },
+        { type: 'process', script: taskLabel, path: resourceUri.fsPath },
         vscode.TaskScope.Workspace,
         taskLabel,
         'makefile',
         shellExec,
       );
-      return { task, command: full, cwd: makeCwd };
+      return { task, command: full, cwd: makeFileCwd, native: false };
     }
     case 'dockerfile': {
       const command = await WorkspaceTasksService.getInstance().resolveTaskCommand(
@@ -754,7 +760,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
           'dockerfile',
           new vscode.ShellExecution(fullCommand, { cwd }),
         );
-        return { task, command: fullCommand, cwd };
+        return { task, command: fullCommand, cwd, native: false };
       }
       return undefined;
     }
@@ -783,7 +789,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'pipenv',
         shellExec,
       );
-      return { task, command: full, cwd: pipenvCwd };
+      return { task, command: full, cwd: pipenvCwd, native: false };
     }
     case 'venv': {
       const taskUri = item.taskFileUri || item.resourceUri;
@@ -822,7 +828,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'venv',
         shellExec,
       );
-      return { task, command: commandString, cwd };
+      return { task, command: commandString, cwd, native: false };
     }
     case 'msbuild': {
       if (!resourceUri) {
@@ -848,7 +854,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'msbuild',
         new vscode.ShellExecution(msbuildCmd, commandArgs, { cwd: msbuildCwd }),
       );
-      return { task, command: `${msbuildCmd} ${commandArgs.join(' ')}`, cwd: msbuildCwd };
+      return { task, command: `${msbuildCmd} ${commandArgs.join(' ')}`, cwd: msbuildCwd, native: false };
     }
     case 'justfile': {
       const justProvider = new JustfileTaskProvider();
@@ -869,7 +875,7 @@ export async function createTaskForItem(item: TaskItem, args?: string): Promise<
         'just',
         new vscode.ShellExecution(justCommand, justArgs, { cwd: justCwd }),
       );
-      return { task, command: fullCmd, cwd: justCwd };
+      return { task, command: fullCmd, cwd: justCwd, native: false };
     }
     default: {
       // Generic: run as shell command if workspace has a declared task

--- a/src/taskRunner.ts
+++ b/src/taskRunner.ts
@@ -4,6 +4,7 @@ import { TaskStateManager, TaskStatus } from './taskStateManager';
 import { createTaskForItem } from './taskFactory';
 import { QueueService } from './services/queueService';
 import { configuration } from './libs/configuration';
+import { IPresentationOptions } from './taskDefinition';
 
 export class TaskRunner {
   private static instance: TaskRunner;
@@ -13,7 +14,7 @@ export class TaskRunner {
   // We can use an event emitter or just access the state manager and let the caller refresh.
   // Ideally, StateManager fires events. For now, we'll return promises.
 
-  private constructor() {}
+  private constructor() { }
 
   public static getInstance(): TaskRunner {
     if (!TaskRunner.instance) {
@@ -47,63 +48,60 @@ export class TaskRunner {
     }
     task = created.task;
 
-    interface PresentationOptions {
-      reveal?: 'always' | 'silent' | 'never';
-      clear?: boolean;
-      close?: boolean;
-      echo?: boolean;
-      focus?: boolean;
-      panel?: 'dedicated' | 'shared' | 'new';
+    // Check if the task is a compound task (has dependsOn but no execution)
+    // modifying the task object in any way (including presentationOptions) causes executeTask to fail
+    // with "Tasks to execute must include an execution"
+    const isNative = task.execution === undefined || created.native;
+
+    if (!isNative) {
+      const presentationOptionsSetting = configuration.get<IPresentationOptions>('task.presentationOptions', {});
+
+      let reveal: vscode.TaskRevealKind;
+      switch (presentationOptionsSetting.reveal) {
+        case 'always':
+          reveal = vscode.TaskRevealKind.Always;
+          break;
+        case 'silent':
+          reveal = vscode.TaskRevealKind.Silent;
+          break;
+        case 'never':
+          reveal = vscode.TaskRevealKind.Never;
+          break;
+        default:
+          reveal = vscode.TaskRevealKind.Always;
+          break;
+      }
+      let panel: vscode.TaskPanelKind;
+      switch (presentationOptionsSetting.panel) {
+        case 'dedicated':
+          panel = vscode.TaskPanelKind.Dedicated;
+          break;
+        case 'shared':
+          panel = vscode.TaskPanelKind.Shared;
+          break;
+        case 'new':
+          panel = vscode.TaskPanelKind.New;
+          break;
+        default:
+          panel = vscode.TaskPanelKind.Shared;
+          break;
+      }
+
+      const presentation: vscode.TaskPresentationOptions = {
+        reveal: reveal,
+        clear: presentationOptionsSetting.clear,
+        close: presentationOptionsSetting.close,
+        echo: presentationOptionsSetting.echo,
+        focus: presentationOptionsSetting.focus,
+        panel: panel,
+      };
+
+      // merge the existing task presentation options with the new ones. the task's existing options take precedence
+      task.presentationOptions = {
+        ...presentation,
+        ...task.presentationOptions,
+      };
     }
-
-    const presentationOptionsSetting = configuration.get<PresentationOptions>('task.presentationOptions', {});
-
-    let reveal: vscode.TaskRevealKind;
-    switch (presentationOptionsSetting.reveal) {
-      case 'always':
-        reveal = vscode.TaskRevealKind.Always;
-        break;
-      case 'silent':
-        reveal = vscode.TaskRevealKind.Silent;
-        break;
-      case 'never':
-        reveal = vscode.TaskRevealKind.Never;
-        break;
-      default:
-        reveal = vscode.TaskRevealKind.Always;
-        break;
-    }
-    let panel: vscode.TaskPanelKind;
-    switch (presentationOptionsSetting.panel) {
-      case 'dedicated':
-        panel = vscode.TaskPanelKind.Dedicated;
-        break;
-      case 'shared':
-        panel = vscode.TaskPanelKind.Shared;
-        break;
-      case 'new':
-        panel = vscode.TaskPanelKind.New;
-        break;
-      default:
-        panel = vscode.TaskPanelKind.Shared;
-        break;
-    }
-
-    const presentation: vscode.TaskPresentationOptions = {
-      reveal: reveal,
-      clear: presentationOptionsSetting.clear,
-      close: presentationOptionsSetting.close,
-      echo: presentationOptionsSetting.echo,
-      focus: presentationOptionsSetting.focus,
-      panel: panel,
-    };
-
-    // merge the existing task presentation options with the new ones. the task's existing options take precedence
-    task.presentationOptions = {
-      ...presentation,
-      ...task.presentationOptions,
-    };
-
     // Extra debug info for gulp tasks
     // if (item.taskType === 'gulp') {
     //   console.log(`[TaskRunner] Running gulp task '${taskLabel}' from file: ${item.resourceUri?.fsPath} -- command: ${created.command}`);
@@ -114,8 +112,15 @@ export class TaskRunner {
     vscode.commands.executeCommand('workspaceTasks.refreshTree'); // Trigger refresh
 
     try {
+      // serialize the task, and log it to see what we get.
+      console.log(`[TaskRunner] Executing task: ${JSON.stringify(task, null, 2)}`);
       const execution = await vscode.tasks.executeTask(task);
       TaskStateManager.getInstance().setExecution(id, execution);
+      if (isNative && task.execution === undefined) {
+        // Compound tasks don't have an execution, so we just mark them as success
+        TaskStateManager.getInstance().setStatus(id, 'success');
+        vscode.commands.executeCommand('workspaceTasks.refreshTree');
+      }
     } catch (e) {
       console.error('[TaskRunner] executeTask failed:', e);
       TaskStateManager.getInstance().setStatus(id, 'failure');

--- a/src/taskRunner.ts
+++ b/src/taskRunner.ts
@@ -112,8 +112,6 @@ export class TaskRunner {
     vscode.commands.executeCommand('workspaceTasks.refreshTree'); // Trigger refresh
 
     try {
-      // serialize the task, and log it to see what we get.
-      console.log(`[TaskRunner] Executing task: ${JSON.stringify(task, null, 2)}`);
       const execution = await vscode.tasks.executeTask(task);
       TaskStateManager.getInstance().setExecution(id, execution);
       if (isNative && task.execution === undefined) {

--- a/src/taskRunner.ts
+++ b/src/taskRunner.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 import { TaskItem } from './taskItem';
 import { TaskStateManager, TaskStatus } from './taskStateManager';
 import { createTaskForItem } from './taskFactory';

--- a/src/test/suite/taskFactoryGulp.test.ts
+++ b/src/test/suite/taskFactoryGulp.test.ts
@@ -24,7 +24,7 @@ suite('TaskFactory Gulp Tests', () => {
     // In the test environment, the workspace root is the extension root
     // And TaskFactory Gulp logic explicitly prefers workspace root as CWD
     const workspaceRoot = vscode.workspace.workspaceFolders![0].uri.fsPath;
-    assert.strictEqual(created?.cwd.toLowerCase(), workspaceRoot.toLowerCase());
+    assert.strictEqual(created?.cwd?.toLowerCase(), workspaceRoot.toLowerCase());
 
     // Since the gulpfile lives in a subfolder, the command should include --gulpfile with its path
     assert.ok(

--- a/src/test/suite/taskFactoryNpm.test.ts
+++ b/src/test/suite/taskFactoryNpm.test.ts
@@ -25,7 +25,7 @@ suite('Task Factory NPM Test Suite', () => {
     assert.ok(created, 'Should create a task');
     // Check CWD. It should be the subdirectory.
     // Normalize paths for comparison (lowercase on Windows)
-    const createdCwd = created?.cwd.toLowerCase();
+    const createdCwd = created?.cwd?.toLowerCase();
     const expectedCwd = subDir.toLowerCase();
 
     assert.strictEqual(createdCwd, expectedCwd, `CWD should be ${expectedCwd} but was ${createdCwd}`);


### PR DESCRIPTION
- #49 fix: Treat vscode tasks as they are natively defined by vscode
- #50 fix: Treat vscode tasks as they are natively defined by vscode
- #56 fix: Treat vscode tasks as they are natively defined by vscode
- Added some initial work for a task definition overhaul. 